### PR TITLE
Use stable coroutines

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "org.jetbrains.anko:anko-commons:$anko_version"
     implementation "org.jetbrains.anko:anko-coroutines:$anko_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.30.2'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.0.0'
     implementation "com.android.support:design:$support_version"
     implementation "com.android.support:preference-v14:$support_version"
     implementation "com.android.support:support-v4:$support_version"

--- a/app/src/main/kotlin/net/syncthing/lite/activities/FolderBrowserActivity.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/activities/FolderBrowserActivity.kt
@@ -5,8 +5,9 @@ import android.content.Intent
 import android.databinding.DataBindingUtil
 import android.os.Bundle
 import android.util.Log
-import kotlinx.coroutines.experimental.android.UI
-import kotlinx.coroutines.experimental.async
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import net.syncthing.java.bep.IndexBrowser
 import net.syncthing.java.core.beans.FileInfo
 import net.syncthing.java.core.beans.FolderInfo
@@ -70,7 +71,7 @@ class FolderBrowserActivity : SyncthingActivity() {
     override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
         if (requestCode == REQUEST_SELECT_UPLOAD_FILE && resultCode == Activity.RESULT_OK) {
             libraryHandler?.syncthingClient { syncthingClient ->
-                async (UI) {
+                GlobalScope.launch (Dispatchers.Main) {
                     // FIXME: it would be better if the dialog would use the library handler
                     FileUploadDialog(this@FolderBrowserActivity, syncthingClient, intent!!.data,
                             indexBrowser.folder, indexBrowser.currentPath,
@@ -114,7 +115,7 @@ class FolderBrowserActivity : SyncthingActivity() {
             async {
                 val list = indexBrowser.listFiles()
 
-                async (UI) {
+                GlobalScope.launch (Dispatchers.Main) {
                     Log.i("navigateToFolder", "list for path = '" + indexBrowser.currentPath + "' list = " + list.size + " records")
                     Log.d("navigateToFolder", "list for path = '" + indexBrowser.currentPath + "' list = " + list)
                     assert(!list.isEmpty())//list must contain at least the 'parent' path
@@ -124,7 +125,7 @@ class FolderBrowserActivity : SyncthingActivity() {
                         libraryHandler?.folderBrowser {
                             val title = it.getFolderInfo(indexBrowser.folder)?.label
 
-                            async(UI) {
+                            GlobalScope.launch (Dispatchers.Main) {
                                 supportActionBar?.title = title
                             }
                         }

--- a/app/src/main/kotlin/net/syncthing/lite/activities/IntroActivity.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/activities/IntroActivity.kt
@@ -4,8 +4,6 @@ import android.arch.lifecycle.Observer
 import android.content.Intent
 import android.databinding.DataBindingUtil
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
 import android.support.v4.app.Fragment
 import android.support.v4.content.ContextCompat
 import android.text.Html

--- a/app/src/main/kotlin/net/syncthing/lite/activities/IntroActivity.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/activities/IntroActivity.kt
@@ -15,8 +15,9 @@ import android.view.ViewGroup
 import android.widget.Button
 import com.github.paolorotolo.appintro.AppIntro
 import com.google.zxing.integration.android.IntentIntegrator
-import kotlinx.coroutines.experimental.android.UI
-import kotlinx.coroutines.experimental.async
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import net.syncthing.java.core.beans.DeviceId
 import net.syncthing.lite.R
 import net.syncthing.lite.databinding.FragmentIntroOneBinding
@@ -183,7 +184,7 @@ class IntroActivity : AppIntro() {
             binding = DataBindingUtil.inflate(inflater, R.layout.fragment_intro_three, container, false)
 
             libraryHandler.library { config, client, _ ->
-                async(UI) {
+                GlobalScope.launch (Dispatchers.Main) {
                     client.addOnConnectionChangedListener(this@IntroFragmentThree::onConnectionChanged)
                     val deviceId = config.localDeviceId.deviceId
                     val desc = activity?.getString(R.string.intro_page_three_description, "<b>$deviceId</b>")
@@ -196,7 +197,7 @@ class IntroActivity : AppIntro() {
 
         private fun onConnectionChanged(deviceId: DeviceId) {
             libraryHandler.library { config, client, _ ->
-                async(UI) {
+                GlobalScope.launch (Dispatchers.Main) {
                     if (config.folders.isNotEmpty()) {
                         client.removeOnConnectionChangedListener(this@IntroFragmentThree::onConnectionChanged)
                         (activity as IntroActivity?)?.onDonePressed(this@IntroFragmentThree)

--- a/app/src/main/kotlin/net/syncthing/lite/activities/MainActivity.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/activities/MainActivity.kt
@@ -8,8 +8,9 @@ import android.support.v4.app.Fragment
 import android.support.v7.app.ActionBarDrawerToggle
 import android.view.Gravity
 import android.view.MenuItem
-import kotlinx.coroutines.experimental.android.UI
-import kotlinx.coroutines.experimental.async
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import net.syncthing.lite.R
 import net.syncthing.lite.databinding.ActivityMainBinding
 import net.syncthing.lite.dialogs.DeviceIdDialogFragment
@@ -101,7 +102,7 @@ class MainActivity : SyncthingActivity() {
     }
 
     private fun cleanCacheAndIndex() {
-        async(UI) {
+        GlobalScope.launch (Dispatchers.Main) {
             libraryHandler.syncthingClient { it.clearCacheAndIndex() }
             recreate()
         }

--- a/app/src/main/kotlin/net/syncthing/lite/activities/SyncthingActivity.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/activities/SyncthingActivity.kt
@@ -1,7 +1,6 @@
 package net.syncthing.lite.activities
 
 import android.app.AlertDialog
-import android.content.Context
 import android.databinding.DataBindingUtil
 import android.os.Bundle
 import android.support.design.widget.Snackbar

--- a/app/src/main/kotlin/net/syncthing/lite/dialogs/DeviceIdDialogFragment.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/dialogs/DeviceIdDialogFragment.kt
@@ -17,8 +17,9 @@ import android.widget.Toast
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.WriterException
 import com.google.zxing.qrcode.QRCodeWriter
-import kotlinx.coroutines.experimental.android.UI
-import kotlinx.coroutines.experimental.async
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import net.syncthing.lite.R
 import net.syncthing.lite.databinding.DialogDeviceIdBinding
 import net.syncthing.lite.fragments.SyncthingDialogFragment
@@ -62,7 +63,7 @@ class DeviceIdDialogFragment: SyncthingDialogFragment() {
                 ))
             }
 
-            async (UI) {
+            GlobalScope.launch (Dispatchers.Main) {
                 binding.deviceId.text = deviceId.deviceId
                 binding.deviceId.visibility = View.VISIBLE
 
@@ -83,7 +84,7 @@ class DeviceIdDialogFragment: SyncthingDialogFragment() {
                         }
                     }
 
-                    async(UI) {
+                    GlobalScope.launch (Dispatchers.Main) {
                         binding.flipper.displayedChild = 1
                         binding.qrCode.setImageBitmap(bmp)
                     }

--- a/app/src/main/kotlin/net/syncthing/lite/dialogs/FileUploadDialog.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/dialogs/FileUploadDialog.kt
@@ -3,8 +3,6 @@ package net.syncthing.lite.dialogs
 import android.app.ProgressDialog
 import android.content.Context
 import android.net.Uri
-import kotlinx.coroutines.experimental.android.UI
-import kotlinx.coroutines.experimental.async
 import net.syncthing.java.bep.BlockPusher
 import net.syncthing.java.client.SyncthingClient
 import net.syncthing.lite.R

--- a/app/src/main/kotlin/net/syncthing/lite/fragments/DevicesFragment.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/fragments/DevicesFragment.kt
@@ -10,8 +10,9 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import com.google.zxing.integration.android.IntentIntegrator
-import kotlinx.coroutines.experimental.android.UI
-import kotlinx.coroutines.experimental.async
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import net.syncthing.java.core.beans.DeviceInfo
 import net.syncthing.lite.R
 import net.syncthing.lite.adapters.DeviceAdapterListener
@@ -76,7 +77,7 @@ class DevicesFragment : SyncthingFragment() {
 
     private fun updateDeviceList() {
         libraryHandler.syncthingClient { syncthingClient ->
-            async(UI) {
+            GlobalScope.launch (Dispatchers.Main) {
                 adapter.data = syncthingClient.getPeerStatus()
                 binding.isEmpty = adapter.data.isEmpty()
             }

--- a/app/src/main/kotlin/net/syncthing/lite/fragments/FoldersFragment.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/fragments/FoldersFragment.kt
@@ -6,8 +6,9 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import kotlinx.coroutines.experimental.android.UI
-import kotlinx.coroutines.experimental.async
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import net.syncthing.java.core.beans.FolderInfo
 import net.syncthing.java.core.beans.FolderStats
 import net.syncthing.lite.activities.FolderBrowserActivity
@@ -39,7 +40,7 @@ class FoldersFragment : SyncthingFragment() {
         libraryHandler.folderBrowser { folderBrowser ->
             val list = folderBrowser.folderInfoAndStatsList()
 
-            async (UI) {
+            GlobalScope.launch (Dispatchers.Main) {
                 Log.i(TAG, "list folders = " + list + " (" + list.size + " records)")
                 val adapter = FoldersListAdapter().apply { data = list }
                 binding.list.adapter = adapter

--- a/app/src/main/kotlin/net/syncthing/lite/library/DownloadFileTask.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/library/DownloadFileTask.kt
@@ -4,8 +4,9 @@ import android.os.Handler
 import android.os.Looper
 import android.support.v4.os.CancellationSignal
 import android.util.Log
-import kotlinx.coroutines.experimental.launch
-import kotlinx.coroutines.experimental.suspendCancellableCoroutine
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import net.syncthing.java.bep.BlockPullerStatus
 import net.syncthing.java.client.SyncthingClient
 import net.syncthing.java.core.beans.FileInfo
@@ -13,6 +14,8 @@ import net.syncthing.lite.BuildConfig
 import org.apache.commons.io.FileUtils
 import java.io.File
 import java.io.IOException
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 class DownloadFileTask(private val fileStorageDirectory: File,
                        syncthingClient: SyncthingClient,
@@ -58,7 +61,7 @@ class DownloadFileTask(private val fileStorageDirectory: File,
     init {
         val file = DownloadFilePath(fileStorageDirectory, fileInfo.hash!!)
 
-        launch {
+        GlobalScope.launch {
             if (file.targetFile.exists()) {
                 if (BuildConfig.DEBUG) {
                     Log.d(TAG, "there is already a file")

--- a/app/src/main/kotlin/net/syncthing/lite/library/LibraryHandler.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/library/LibraryHandler.kt
@@ -6,8 +6,9 @@ import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
-import kotlinx.coroutines.experimental.android.UI
-import kotlinx.coroutines.experimental.async
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import net.syncthing.java.bep.FolderBrowser
 import net.syncthing.java.client.SyncthingClient
 import net.syncthing.java.core.beans.DeviceId
@@ -88,7 +89,7 @@ class LibraryHandler(context: Context,
     private fun onIndexRecordAcquired(folderInfo: FolderInfo, newRecords: List<FileInfo>, indexInfo: IndexInfo) {
         Log.i(TAG, "handleIndexRecordEvent trigger folder list update from index record acquired")
 
-        async(UI) {
+        GlobalScope.launch (Dispatchers.Main) {
             onIndexUpdateProgressListener(folderInfo, (indexInfo.getCompleted() * 100).toInt())
         }
     }
@@ -96,7 +97,7 @@ class LibraryHandler(context: Context,
     private fun onRemoteIndexAcquired(folderInfo: FolderInfo) {
         Log.i(TAG, "handleIndexAcquiredEvent trigger folder list update from index acquired")
 
-        async(UI) {
+        GlobalScope.launch (Dispatchers.Main) {
             onIndexUpdateCompleteListener(folderInfo)
         }
     }

--- a/app/src/main/kotlin/net/syncthing/lite/library/SyncthingProvider.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/library/SyncthingProvider.kt
@@ -8,8 +8,8 @@ import android.provider.DocumentsContract.Document
 import android.provider.DocumentsContract.Root
 import android.provider.DocumentsProvider
 import android.util.Log
-import kotlinx.coroutines.experimental.cancel
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
 import net.syncthing.java.bep.IndexBrowser
 import net.syncthing.java.core.beans.FileInfo
 import net.syncthing.java.core.beans.FolderInfo

--- a/app/src/main/kotlin/net/syncthing/lite/utils/Util.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/utils/Util.kt
@@ -4,8 +4,9 @@ import android.content.Context
 import android.net.Uri
 import android.os.Build
 import android.provider.OpenableColumns
-import kotlinx.coroutines.experimental.android.UI
-import kotlinx.coroutines.experimental.async
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import net.syncthing.java.core.beans.DeviceId
 import net.syncthing.java.core.beans.DeviceInfo
 import net.syncthing.lite.R
@@ -47,12 +48,12 @@ object Util {
             if (!configuration.peerIds.contains(deviceId2)) {
                 configuration.peers = configuration.peers + DeviceInfo(deviceId2, null)
                 configuration.persistLater()
-                async(UI) {
+                GlobalScope.launch (Dispatchers.Main) {
                     context?.toast(context.getString(R.string.device_import_success, deviceId2.shortId))
                     onComplete()
                 }
             } else {
-                async(UI) {
+                GlobalScope.launch (Dispatchers.Main) {
                     context?.toast(context.getString(R.string.device_already_known, deviceId2.shortId))
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.61'
+    ext.kotlin_version = '1.3.0'
     ext.support_version = '27.0.2'
     ext.build_tools_version = '3.2.0'
     ext.anko_version = '0.10.7'

--- a/build.gradle
+++ b/build.gradle
@@ -22,10 +22,10 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
         maven {
             url "https://jitpack.io"
         }
-        google()
     }
 }

--- a/syncthing-bep/build.gradle
+++ b/syncthing-bep/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile project(':syncthing-http-relay-client')
     compile "net.jpountz.lz4:lz4:1.3.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.30.2'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0'
     implementation "com.google.protobuf:protobuf-lite:$protobuf_lite_version"
 }
 

--- a/syncthing-bep/src/main/kotlin/net/syncthing/java/bep/BlockPuller.kt
+++ b/syncthing-bep/src/main/kotlin/net/syncthing/java/bep/BlockPuller.kt
@@ -25,11 +25,12 @@ import net.syncthing.java.core.beans.FileBlocks
 import net.syncthing.java.core.beans.FileInfo
 import net.syncthing.java.core.interfaces.TempRepository
 import net.syncthing.java.core.utils.NetworkUtils
-import org.apache.commons.io.FileUtils
 import org.bouncycastle.util.encoders.Hex
 import org.slf4j.LoggerFactory
-import java.io.*
-import java.lang.Exception
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.io.InputStream
+import java.io.SequenceInputStream
 import java.security.MessageDigest
 import java.util.*
 import kotlin.collections.HashMap

--- a/syncthing-bep/src/main/kotlin/net/syncthing/java/bep/BlockPuller.kt
+++ b/syncthing-bep/src/main/kotlin/net/syncthing/java/bep/BlockPuller.kt
@@ -15,8 +15,8 @@
 package net.syncthing.java.bep
 
 import com.google.protobuf.ByteString
-import kotlinx.coroutines.experimental.*
-import kotlinx.coroutines.experimental.channels.Channel
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
 import net.syncthing.java.bep.BlockExchangeProtos.ErrorCode
 import net.syncthing.java.bep.BlockExchangeProtos.Request
 import net.syncthing.java.bep.utils.longSumBy
@@ -33,6 +33,7 @@ import java.lang.Exception
 import java.security.MessageDigest
 import java.util.*
 import kotlin.collections.HashMap
+import kotlin.coroutines.resume
 
 class BlockPuller internal constructor(private val connectionHandler: ConnectionHandler,
                                        private val indexHandler: IndexHandler,

--- a/syncthing-bep/src/main/kotlin/net/syncthing/java/bep/BlockPusher.kt
+++ b/syncthing-bep/src/main/kotlin/net/syncthing/java/bep/BlockPusher.kt
@@ -17,7 +17,6 @@ import com.google.protobuf.ByteString
 import net.syncthing.java.bep.BlockExchangeProtos.Vector
 import net.syncthing.java.core.beans.*
 import net.syncthing.java.core.beans.FileInfo.Version
-import net.syncthing.java.core.configuration.Configuration
 import net.syncthing.java.core.utils.BlockUtils
 import net.syncthing.java.core.utils.NetworkUtils
 import net.syncthing.java.core.utils.submitLogging

--- a/syncthing-bep/src/main/kotlin/net/syncthing/java/bep/IndexHandler.kt
+++ b/syncthing-bep/src/main/kotlin/net/syncthing/java/bep/IndexHandler.kt
@@ -19,7 +19,6 @@ import net.syncthing.java.core.configuration.Configuration
 import net.syncthing.java.core.interfaces.IndexRepository
 import net.syncthing.java.core.interfaces.Sequencer
 import net.syncthing.java.core.interfaces.TempRepository
-import net.syncthing.java.core.utils.BlockUtils
 import net.syncthing.java.core.utils.NetworkUtils
 import net.syncthing.java.core.utils.awaitTerminationSafe
 import net.syncthing.java.core.utils.submitLogging

--- a/syncthing-client-cli/src/main/kotlin/net/syncthing/java/client/cli/Main.kt
+++ b/syncthing-client-cli/src/main/kotlin/net/syncthing/java/client/cli/Main.kt
@@ -13,12 +13,12 @@
  */
 package net.syncthing.java.client.cli
 
+import net.syncthing.java.client.SyncthingClient
 import net.syncthing.java.core.beans.DeviceId
 import net.syncthing.java.core.beans.DeviceInfo
 import net.syncthing.java.core.beans.FileInfo
 import net.syncthing.java.core.configuration.Configuration
 import net.syncthing.java.repository.repo.SqlRepository
-import net.syncthing.java.client.SyncthingClient
 import org.apache.commons.cli.*
 import org.apache.commons.io.FileUtils
 import org.slf4j.LoggerFactory

--- a/syncthing-client/src/main/kotlin/net/syncthing/java/client/SyncthingClient.kt
+++ b/syncthing-client/src/main/kotlin/net/syncthing/java/client/SyncthingClient.kt
@@ -35,6 +35,21 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.collections.ArrayList
+import kotlin.collections.HashMap
+import kotlin.collections.List
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.distinctBy
+import kotlin.collections.emptySet
+import kotlin.collections.filterNot
+import kotlin.collections.filterNotNull
+import kotlin.collections.find
+import kotlin.collections.forEach
+import kotlin.collections.groupBy
+import kotlin.collections.map
+import kotlin.collections.mutableListOf
+import kotlin.collections.set
+import kotlin.collections.takeWhile
 
 class SyncthingClient(
         private val configuration: Configuration,

--- a/syncthing-core/src/main/kotlin/net/syncthing/java/core/beans/DeviceId.kt
+++ b/syncthing-core/src/main/kotlin/net/syncthing/java/core/beans/DeviceId.kt
@@ -4,7 +4,6 @@ import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonWriter
 import net.syncthing.java.core.utils.NetworkUtils
 import org.apache.commons.codec.binary.Base32
-import org.slf4j.LoggerFactory
 import java.io.IOException
 
 data class DeviceId @Throws(IOException::class) constructor(val deviceId: String) {

--- a/syncthing-core/src/main/kotlin/net/syncthing/java/core/beans/FolderStats.kt
+++ b/syncthing-core/src/main/kotlin/net/syncthing/java/core/beans/FolderStats.kt
@@ -14,8 +14,7 @@
 package net.syncthing.java.core.beans
 
 import org.apache.commons.io.FileUtils
-
-import java.util.Date
+import java.util.*
 
 class FolderStats private constructor(val fileCount: Long, val dirCount: Long, val size: Long, val lastUpdate: Date, folder: String, label: String?) : FolderInfo(folder, label) {
 

--- a/syncthing-discovery/build.gradle
+++ b/syncthing-discovery/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     compile "commons-cli:commons-cli:1.4"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "com.google.protobuf:protobuf-lite:$protobuf_lite_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.30.2'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0'
 }
 
 run {

--- a/syncthing-discovery/src/main/kotlin/net/syncthing/java/discovery/DeviceAddressSupplier.kt
+++ b/syncthing-discovery/src/main/kotlin/net/syncthing/java/discovery/DeviceAddressSupplier.kt
@@ -14,10 +14,10 @@
  */
 package net.syncthing.java.discovery
 
-import kotlinx.coroutines.experimental.CancellationException
-import kotlinx.coroutines.experimental.runBlocking
-import kotlinx.coroutines.experimental.selects.select
-import kotlinx.coroutines.experimental.withTimeout
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.selects.select
+import kotlinx.coroutines.withTimeout
 import net.syncthing.java.core.beans.DeviceAddress
 import net.syncthing.java.core.beans.DeviceId
 import org.slf4j.LoggerFactory

--- a/syncthing-discovery/src/main/kotlin/net/syncthing/java/discovery/DeviceAddressesManager.kt
+++ b/syncthing-discovery/src/main/kotlin/net/syncthing/java/discovery/DeviceAddressesManager.kt
@@ -13,8 +13,8 @@
  */
 package net.syncthing.java.discovery
 
-import kotlinx.coroutines.experimental.channels.Channel
-import kotlinx.coroutines.experimental.channels.ReceiveChannel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
 import net.syncthing.java.core.beans.DeviceAddress
 import net.syncthing.java.core.beans.DeviceId
 

--- a/syncthing-discovery/src/main/kotlin/net/syncthing/java/discovery/DiscoveryHandler.kt
+++ b/syncthing-discovery/src/main/kotlin/net/syncthing/java/discovery/DiscoveryHandler.kt
@@ -14,8 +14,8 @@
  */
 package net.syncthing.java.discovery
 
-import kotlinx.coroutines.experimental.GlobalScope
-import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import net.syncthing.java.core.beans.DeviceAddress
 import net.syncthing.java.core.beans.DeviceId
 import net.syncthing.java.core.configuration.Configuration

--- a/syncthing-discovery/src/main/kotlin/net/syncthing/java/discovery/protocol/GlobalDiscoveryHandler.kt
+++ b/syncthing-discovery/src/main/kotlin/net/syncthing/java/discovery/protocol/GlobalDiscoveryHandler.kt
@@ -14,10 +14,10 @@
  */
 package net.syncthing.java.discovery.protocol
 
-import kotlinx.coroutines.experimental.GlobalScope
-import kotlinx.coroutines.experimental.async
-import kotlinx.coroutines.experimental.coroutineScope
-import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import net.syncthing.java.core.beans.DeviceAddress
 import net.syncthing.java.core.beans.DeviceId
 import net.syncthing.java.core.configuration.Configuration

--- a/syncthing-discovery/src/main/kotlin/net/syncthing/java/discovery/protocol/GlobalDiscoveryUtil.kt
+++ b/syncthing-discovery/src/main/kotlin/net/syncthing/java/discovery/protocol/GlobalDiscoveryUtil.kt
@@ -15,8 +15,8 @@
 package net.syncthing.java.discovery.protocol
 
 import com.google.gson.stream.JsonReader
-import kotlinx.coroutines.experimental.Dispatchers
-import kotlinx.coroutines.experimental.withContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import net.syncthing.java.core.beans.DeviceId
 import java.io.BufferedInputStream
 import java.io.IOException

--- a/syncthing-discovery/src/main/kotlin/net/syncthing/java/discovery/protocol/LocalDiscoveryHandler.kt
+++ b/syncthing-discovery/src/main/kotlin/net/syncthing/java/discovery/protocol/LocalDiscoveryHandler.kt
@@ -14,10 +14,10 @@
  */
 package net.syncthing.java.discovery.protocol
 
-import kotlinx.coroutines.experimental.GlobalScope
-import kotlinx.coroutines.experimental.Job
-import kotlinx.coroutines.experimental.channels.consumeEach
-import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.launch
 import net.syncthing.java.core.beans.DeviceId
 import net.syncthing.java.core.configuration.Configuration
 import org.slf4j.LoggerFactory

--- a/syncthing-discovery/src/main/kotlin/net/syncthing/java/discovery/protocol/LocalDiscoveryUtil.kt
+++ b/syncthing-discovery/src/main/kotlin/net/syncthing/java/discovery/protocol/LocalDiscoveryUtil.kt
@@ -15,11 +15,11 @@
 package net.syncthing.java.discovery.protocol
 
 import com.google.protobuf.ByteString
-import kotlinx.coroutines.experimental.Dispatchers
-import kotlinx.coroutines.experimental.GlobalScope
-import kotlinx.coroutines.experimental.channels.ReceiveChannel
-import kotlinx.coroutines.experimental.channels.produce
-import kotlinx.coroutines.experimental.withContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.produce
+import kotlinx.coroutines.withContext
 import net.syncthing.java.core.beans.DeviceAddress
 import net.syncthing.java.core.beans.DeviceId
 import net.syncthing.java.core.utils.NetworkUtils

--- a/syncthing-discovery/src/main/kotlin/net/syncthing/java/discovery/utils/AddressRanker.kt
+++ b/syncthing-discovery/src/main/kotlin/net/syncthing/java/discovery/utils/AddressRanker.kt
@@ -14,7 +14,7 @@
  */
 package net.syncthing.java.discovery.utils
 
-import kotlinx.coroutines.experimental.*
+import kotlinx.coroutines.*
 import net.syncthing.java.core.beans.DeviceAddress
 import net.syncthing.java.core.beans.DeviceAddress.AddressType
 import org.slf4j.LoggerFactory


### PR DESCRIPTION
> By the way, unrelated to this PR but Travis is showing a lot of warnings in the build log. Would be good to fix them, or suppress irrelevant ones. Running Analyze -> Inspect Code in Android Studio should actually fix most of them, but that's not working right for me...

(https://github.com/syncthing/syncthing-lite/pull/71#issuecomment-436283023)

This updates Kotlin which allows using the stable version of coroutines. This removes many warnings. The remaining ones are mostly in old code.