### PR TITLE
Selective folder sharing

### DIFF
--- a/app/src/main/kotlin/net/syncthing/lite/adapters/FoldersListAdapter.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/adapters/FoldersListAdapter.kt
@@ -55,6 +55,10 @@ class FoldersListAdapter: RecyclerView.Adapter<FolderListViewHolder>() {
         binding.root.setOnClickListener {
             listener?.onFolderClicked(folderInfo, folderStats)
         }
+
+        binding.root.setOnLongClickListener {
+            listener?.onFolderLongClicked(folderInfo) ?: false
+        }
     }
 }
 
@@ -62,4 +66,5 @@ class FolderListViewHolder(val binding: ListviewFolderBinding): RecyclerView.Vie
 
 interface FolderListAdapterListener {
     fun onFolderClicked(folderInfo: FolderInfo, folderStats: FolderStats)
+    fun onFolderLongClicked(folderInfo: FolderInfo): Boolean
 }

--- a/app/src/main/kotlin/net/syncthing/lite/async/CoroutineDialogFragment.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/async/CoroutineDialogFragment.kt
@@ -1,0 +1,19 @@
+package net.syncthing.lite.async
+
+import android.support.v4.app.DialogFragment
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlin.coroutines.CoroutineContext
+
+abstract class CoroutineDialogFragment: DialogFragment(), CoroutineScope {
+    val job = Job()
+
+    override val coroutineContext: CoroutineContext
+        get() = job + Dispatchers.Main
+
+    override fun onDestroy() {
+        super.onDestroy()
+        job.cancel()
+    }
+}

--- a/app/src/main/kotlin/net/syncthing/lite/dialogs/EnableFolderSyncForNewDeviceDialog.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/dialogs/EnableFolderSyncForNewDeviceDialog.kt
@@ -1,0 +1,111 @@
+package net.syncthing.lite.dialogs
+
+import android.app.AlertDialog
+import android.app.Dialog
+import android.os.Bundle
+import android.support.v4.app.FragmentManager
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import net.syncthing.java.core.beans.DeviceInfo
+import net.syncthing.lite.R
+import net.syncthing.lite.fragments.SyncthingDialogFragment
+
+class EnableFolderSyncForNewDeviceDialog: SyncthingDialogFragment() {
+    companion object {
+        private const val FOLDER_ID = "folderId"
+        private const val FOLDER_NAME = "folderName"
+        private const val DEVICES = "devices"
+        private const val STATUS_CURRENT_DEVICE_ID = "currentDeviceId"
+
+        private const val TAG = "EnableFolderSyncForNewDeviceDialog"
+
+        fun newInstance(folderId: String, folderName: String, devices: List<DeviceInfo>) = EnableFolderSyncForNewDeviceDialog().apply {
+            arguments = Bundle().apply {
+                putString(FOLDER_ID, folderId)
+                putString(FOLDER_NAME, folderName)
+                putSerializable(DEVICES, ArrayList<DeviceInfo>(devices))
+            }
+        }
+    }
+
+    private var currentDeviceId = 0
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val folderId = arguments!!.getString(FOLDER_ID)
+        val folderName = arguments!!.getString(FOLDER_NAME)
+        val devices = arguments!!.getSerializable(DEVICES) as ArrayList<DeviceInfo>
+
+        if (savedInstanceState != null) {
+            currentDeviceId = savedInstanceState.getInt(STATUS_CURRENT_DEVICE_ID)
+        }
+
+        val dialog = AlertDialog.Builder(context!!)
+                .setTitle(R.string.dialog_enable_folder_sync_for_new_device_title)
+                .setMessage(R.string.dialog_enable_folder_sync_for_new_device_text)
+                .setPositiveButton(R.string.dialog_enable_folder_sync_for_new_device_positive, null)
+                .setNegativeButton(R.string.dialog_enable_folder_sync_for_new_device_negative, null)
+                .create()
+
+        fun bindDeviceId() {
+            if (currentDeviceId >= devices.size) {
+                dismissAllowingStateLoss()
+            } else {
+                val device = devices[currentDeviceId]
+
+                dialog.setMessage(getString(
+                        R.string.dialog_enable_folder_sync_for_new_device_text,
+                        folderName,
+                        device.deviceId,
+                        device.name
+                ))
+
+                dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                    GlobalScope.launch {
+                        libraryHandler.libraryManager.withLibrary {
+                            val oldFolderEntry = it.configuration.folders.find { it.folderId == folderId }!!
+
+                            it.configuration.folders = it.configuration.folders.filter { it != oldFolderEntry }.toSet() + setOf(
+                                    oldFolderEntry.copy(
+                                            deviceIdWhitelist = oldFolderEntry.deviceIdWhitelist + setOf(device.deviceId),
+                                            deviceIdBlacklist = oldFolderEntry.deviceIdBlacklist - setOf(device.deviceId)
+                                    )
+                            )
+                        }
+                    }
+
+                    currentDeviceId++
+                    bindDeviceId()
+                }
+
+                dialog.getButton(AlertDialog.BUTTON_NEGATIVE).setOnClickListener {
+                    GlobalScope.launch {
+                        libraryHandler.libraryManager.withLibrary {
+                            val oldFolderEntry = it.configuration.folders.find { it.folderId == folderId }!!
+
+                            it.configuration.folders = it.configuration.folders.filter { it != oldFolderEntry }.toSet() + setOf(
+                                    oldFolderEntry.copy(
+                                            ignoredDeviceIdList = oldFolderEntry.deviceIdWhitelist + setOf(device.deviceId)
+                                    )
+                            )
+                        }
+                    }
+
+                    currentDeviceId++
+                    bindDeviceId()
+                }
+            }
+        }
+
+        dialog.setOnShowListener { bindDeviceId() }
+
+        return dialog
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+
+        outState.putInt(STATUS_CURRENT_DEVICE_ID, currentDeviceId)
+    }
+
+    fun show(fragmentManager: FragmentManager) = show(fragmentManager, TAG)
+}

--- a/app/src/main/kotlin/net/syncthing/lite/dialogs/EnableFolderSyncForNewDeviceDialog.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/dialogs/EnableFolderSyncForNewDeviceDialog.kt
@@ -55,8 +55,8 @@ class EnableFolderSyncForNewDeviceDialog: SyncthingDialogFragment() {
                 dialog.setMessage(getString(
                         R.string.dialog_enable_folder_sync_for_new_device_text,
                         folderName,
-                        device.deviceId,
-                        device.name
+                        device.name,
+                        device.deviceId.deviceId
                 ))
 
                 dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
@@ -71,6 +71,7 @@ class EnableFolderSyncForNewDeviceDialog: SyncthingDialogFragment() {
                                     )
                             )
 
+                            it.syncthingClient.reconnect(device.deviceId)
                             it.configuration.persistLater()
                         }
                     }
@@ -90,6 +91,7 @@ class EnableFolderSyncForNewDeviceDialog: SyncthingDialogFragment() {
                                     )
                             )
 
+                            it.syncthingClient.reconnect(device.deviceId)
                             it.configuration.persistLater()
                         }
                     }

--- a/app/src/main/kotlin/net/syncthing/lite/dialogs/EnableFolderSyncForNewDeviceDialog.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/dialogs/EnableFolderSyncForNewDeviceDialog.kt
@@ -70,6 +70,8 @@ class EnableFolderSyncForNewDeviceDialog: SyncthingDialogFragment() {
                                             deviceIdBlacklist = oldFolderEntry.deviceIdBlacklist - setOf(device.deviceId)
                                     )
                             )
+
+                            it.configuration.persistLater()
                         }
                     }
 
@@ -87,6 +89,8 @@ class EnableFolderSyncForNewDeviceDialog: SyncthingDialogFragment() {
                                             ignoredDeviceIdList = oldFolderEntry.deviceIdWhitelist + setOf(device.deviceId)
                                     )
                             )
+
+                            it.configuration.persistLater()
                         }
                     }
 

--- a/app/src/main/kotlin/net/syncthing/lite/dialogs/FolderInfoDialog.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/dialogs/FolderInfoDialog.kt
@@ -62,7 +62,7 @@ class FolderInfoDialog: SyncthingDialogFragment() {
                             isChecked = folderInfo.deviceIdWhitelist.contains(deviceId)
 
                             setOnCheckedChangeListener { _, isShared ->
-                                launch {
+                                this@FolderInfoDialog.launch {
                                     libraryHandler.libraryManager.withLibrary { library ->
                                         val oldFolders = library.configuration.folders
                                         var folderToChange = oldFolders.find { it.folderId == folderId }!!

--- a/app/src/main/kotlin/net/syncthing/lite/dialogs/FolderInfoDialog.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/dialogs/FolderInfoDialog.kt
@@ -1,0 +1,103 @@
+package net.syncthing.lite.dialogs
+
+import android.app.Dialog
+import android.os.Bundle
+import android.support.v4.app.FragmentManager
+import android.support.v7.app.AlertDialog
+import android.support.v7.widget.AppCompatCheckBox
+import android.view.LayoutInflater
+import kotlinx.coroutines.launch
+import net.syncthing.lite.R
+import net.syncthing.lite.databinding.DialogFolderInfoBinding
+import net.syncthing.lite.fragments.SyncthingDialogFragment
+
+class FolderInfoDialog: SyncthingDialogFragment() {
+    companion object {
+        fun newInstance(folderId: String) = FolderInfoDialog().apply {
+            arguments = Bundle().apply {
+                putString(FOLDER_ID, folderId)
+            }
+        }
+
+        private const val FOLDER_ID = "folderId"
+        private const val TAG = "FolderInfoDialog"
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val folderId = arguments!!.getString(FOLDER_ID)
+        val binding = DialogFolderInfoBinding.inflate(LayoutInflater.from(context))
+
+        val dialog = AlertDialog.Builder(context!!)
+                .setTitle(folderId)
+                .setView(binding.root)
+                .create()
+
+        launch {
+            val configuration = libraryHandler.libraryManager.withLibrary { it.configuration }
+
+            val folderInfo = configuration.folders.find { it.folderId == folderId }
+
+            if (folderInfo == null) {
+                dismissAllowingStateLoss()
+                return@launch
+            }
+
+            dialog.setTitle(folderInfo.label)
+
+            binding.deviceCheckboxesContainer.removeAllViews()
+
+            val allRelatedDevices = (folderInfo.deviceIdWhitelist + folderInfo.deviceIdBlacklist).toSet()
+
+            allRelatedDevices.forEach { deviceId ->
+                val deviceInfo = configuration.peers.find { it.deviceId == deviceId }
+
+                val deviceLabel = if (deviceInfo == null)
+                    deviceId.deviceId
+                else
+                    context!!.getString(R.string.dialog_folder_info_device_list_item, deviceInfo.name, deviceId.deviceId)
+
+                binding.deviceCheckboxesContainer.addView(
+                        AppCompatCheckBox(context!!).apply {
+                            text = deviceLabel
+                            isChecked = folderInfo.deviceIdWhitelist.contains(deviceId)
+
+                            setOnCheckedChangeListener { _, isShared ->
+                                launch {
+                                    libraryHandler.libraryManager.withLibrary { library ->
+                                        val oldFolders = library.configuration.folders
+                                        var folderToChange = oldFolders.find { it.folderId == folderId }!!
+                                        val foldersNotToChange = oldFolders.filterNot { it.folderId == folderId }.toSet()
+
+                                        if (isShared) {
+                                            folderToChange = folderToChange.copy(
+                                                    ignoredDeviceIdList = folderToChange.ignoredDeviceIdList.filterNot { it == deviceId }.toSet(),
+                                                    deviceIdBlacklist = folderToChange.deviceIdBlacklist.filterNot { it == deviceId }.toSet(),
+                                                    deviceIdWhitelist = folderToChange.deviceIdWhitelist + setOf(deviceId)
+                                            )
+                                        } else {
+                                            folderToChange = folderToChange.copy(
+                                                    deviceIdWhitelist = folderToChange.deviceIdWhitelist.filterNot { it == deviceId }.toSet(),
+                                                    deviceIdBlacklist = folderToChange.deviceIdBlacklist + setOf(deviceId),
+                                                    ignoredDeviceIdList = folderToChange.ignoredDeviceIdList + setOf(deviceId)
+                                            )
+                                        }
+
+                                        // update the config
+                                        library.configuration.folders = foldersNotToChange + setOf(folderToChange)
+                                        library.configuration.persistLater()
+
+                                        // apply the change
+                                        library.syncthingClient.reconnect(deviceId)
+                                    }
+                                }
+                            }
+                        }
+                )
+            }
+        }
+
+        return dialog
+    }
+
+    fun show(fragmentManager: FragmentManager) = show(fragmentManager, TAG)
+}

--- a/app/src/main/kotlin/net/syncthing/lite/fragments/FoldersFragment.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/fragments/FoldersFragment.kt
@@ -13,6 +13,7 @@ import net.syncthing.lite.activities.FolderBrowserActivity
 import net.syncthing.lite.adapters.FolderListAdapterListener
 import net.syncthing.lite.adapters.FoldersListAdapter
 import net.syncthing.lite.databinding.FragmentFoldersBinding
+import net.syncthing.lite.dialogs.FolderInfoDialog
 import org.jetbrains.anko.intentFor
 
 class FoldersFragment : SyncthingFragment() {
@@ -26,6 +27,14 @@ class FoldersFragment : SyncthingFragment() {
                                 FolderBrowserActivity.EXTRA_FOLDER_NAME to folderInfo.folderId
                         )
                 )
+            }
+
+            override fun onFolderLongClicked(folderInfo: FolderInfo): Boolean {
+                FolderInfoDialog
+                        .newInstance(folderId = folderInfo.folderId)
+                        .show(fragmentManager!!)
+
+                return true
             }
         }
 

--- a/app/src/main/kotlin/net/syncthing/lite/fragments/SyncthingDialogFragment.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/fragments/SyncthingDialogFragment.kt
@@ -1,9 +1,9 @@
 package net.syncthing.lite.fragments
 
-import android.support.v4.app.DialogFragment
+import net.syncthing.lite.async.CoroutineDialogFragment
 import net.syncthing.lite.library.LibraryHandler
 
-abstract class SyncthingDialogFragment : DialogFragment() {
+abstract class SyncthingDialogFragment : CoroutineDialogFragment() {
     val libraryHandler: LibraryHandler by lazy { LibraryHandler(
             context = context!!
     )}

--- a/app/src/main/kotlin/net/syncthing/lite/utils/Util.kt
+++ b/app/src/main/kotlin/net/syncthing/lite/utils/Util.kt
@@ -46,7 +46,7 @@ object Util {
         val deviceId2 = DeviceId(deviceId.toUpperCase(Locale.US))
         libraryHandler?.library { configuration, syncthingClient, _ ->
             if (!configuration.peerIds.contains(deviceId2)) {
-                configuration.peers = configuration.peers + DeviceInfo(deviceId2, null)
+                configuration.peers = configuration.peers + DeviceInfo(deviceId2, deviceId2.shortId)
                 configuration.persistLater()
                 syncthingClient.connectToNewlyAddedDevices()
                 GlobalScope.launch (Dispatchers.Main) {

--- a/app/src/main/res/layout/dialog_folder_info.xml
+++ b/app/src/main/res/layout/dialog_folder_info.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <LinearLayout
+        android:padding="8dp"
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:textAppearance="?android:textAppearanceMedium"
+            android:text="@string/dialog_folder_info_device_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <LinearLayout
+            android:id="@+id/device_checkboxes_container"
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <!--
+            <CheckBox
+                android:text="Test device 1 (the very very very very very very very very very very very long id)"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <CheckBox
+                android:text="Test device 2 (the very very very very very very very very very very very long id)"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+            -->
+
+        </LinearLayout>
+
+    </LinearLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,4 +73,6 @@
     <string name="dialog_enable_folder_sync_for_new_device_text">Do you want to sync %1$s with %2$s (%3$s)?</string>
     <string name="dialog_enable_folder_sync_for_new_device_positive">Sync</string>
     <string name="dialog_enable_folder_sync_for_new_device_negative">Do not sync</string>
+    <string name="dialog_folder_info_device_list">Share folder with:</string>
+    <string name="dialog_folder_info_device_list_item">%1$s (%2$s)</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,4 +69,8 @@
     <string name="device_status_connected">Connected to %s</string>
     <string name="device_status_disconnected">Will retry connecting soon - there are %d known addresses</string>
     <string name="device_status_no_address">No known address for the device</string>
+    <string name="dialog_enable_folder_sync_for_new_device_title">Enable folder sync for new device</string>
+    <string name="dialog_enable_folder_sync_for_new_device_text">Do you want to sync %1$s with %2$s (%3$s)?</string>
+    <string name="dialog_enable_folder_sync_for_new_device_positive">Sync</string>
+    <string name="dialog_enable_folder_sync_for_new_device_negative">Do not sync</string>
 </resources>

--- a/syncthing-bep/src/main/kotlin/net/syncthing/java/bep/connectionactor/ClusterConfigHandler.kt
+++ b/syncthing-bep/src/main/kotlin/net/syncthing/java/bep/connectionactor/ClusterConfigHandler.kt
@@ -33,42 +33,44 @@ object ClusterConfigHandler {
         val builder = BlockExchangeProtos.ClusterConfig.newBuilder()
 
         indexHandler.indexRepository.runInTransaction { indexTransaction ->
-            for (folder in configuration.folders) {
-                val folderBuilder = BlockExchangeProtos.Folder.newBuilder()
-                        .setId(folder.folderId)
-                        .setLabel(folder.label)
+            configuration.folders
+                    .filter { it.deviceIdWhitelist.contains(deviceId) }
+                    .forEach { folder ->
+                        val folderBuilder = BlockExchangeProtos.Folder.newBuilder()
+                                .setId(folder.folderId)
+                                .setLabel(folder.label)
 
-                // add this device
-                folderBuilder.addDevices(
-                        BlockExchangeProtos.Device.newBuilder()
-                                .setId(ByteString.copyFrom(configuration.localDeviceId.toHashData()))
-                                .setIndexId(indexTransaction.getSequencer().indexId())
-                                .setMaxSequence(indexTransaction.getSequencer().currentSequence())
-                )
+                        // add this device
+                        folderBuilder.addDevices(
+                                BlockExchangeProtos.Device.newBuilder()
+                                        .setId(ByteString.copyFrom(configuration.localDeviceId.toHashData()))
+                                        .setIndexId(indexTransaction.getSequencer().indexId())
+                                        .setMaxSequence(indexTransaction.getSequencer().currentSequence())
+                        )
 
-                // add other device
-                val indexSequenceInfo = indexTransaction.findIndexInfoByDeviceAndFolder(deviceId, folder.folderId)
+                        // add other device
+                        val indexSequenceInfo = indexTransaction.findIndexInfoByDeviceAndFolder(deviceId, folder.folderId)
 
-                folderBuilder.addDevices(
-                        BlockExchangeProtos.Device.newBuilder()
-                                .setId(ByteString.copyFrom(deviceId.toHashData()))
-                                .apply {
-                                    indexSequenceInfo?.let {
-                                        setIndexId(indexSequenceInfo.indexId)
-                                        setMaxSequence(indexSequenceInfo.localSequence)
+                        folderBuilder.addDevices(
+                                BlockExchangeProtos.Device.newBuilder()
+                                        .setId(ByteString.copyFrom(deviceId.toHashData()))
+                                        .apply {
+                                            indexSequenceInfo?.let {
+                                                indexId = indexSequenceInfo.indexId
+                                                maxSequence = indexSequenceInfo.localSequence
 
-                                        logger.info("send delta index info device = {} index = {} max (local) sequence = {}",
-                                                indexSequenceInfo.deviceId,
-                                                indexSequenceInfo.indexId,
-                                                indexSequenceInfo.localSequence)
-                                    }
-                                }
-                )
+                                                logger.info("send delta index info device = {} index = {} max (local) sequence = {}",
+                                                        indexSequenceInfo.deviceId,
+                                                        indexSequenceInfo.indexId,
+                                                        indexSequenceInfo.localSequence)
+                                            }
+                                        }
+                        )
 
-                builder.addFolders(folderBuilder)
+                        builder.addFolders(folderBuilder)
 
-                // TODO: add the other devices to the cluster config
-            }
+                        // TODO: add the other devices to the cluster config
+                    }
         }
 
         return builder.build()
@@ -85,7 +87,7 @@ object ClusterConfigHandler {
         val newSharedFolders = mutableListOf<FolderInfo>()
 
         for (folder in clusterConfig.foldersList ?: emptyList()) {
-            var folderInfo = ClusterConfigFolderInfo(folder.id, folder.label)
+            var folderInfo = ClusterConfigFolderInfo(folder.id, folder.label, isDeviceInSharedFolderWhitelist = false)
             val devicesById = (folder.devicesList ?: emptyList())
                     .associateBy { input ->
                         DeviceId.fromHashData(input.id!!.toByteArray())
@@ -99,17 +101,30 @@ object ClusterConfigHandler {
                 folderInfo = folderInfo.copy(isShared = true)
                 logger.info("folder shared from device = {} folder = {}", otherDeviceId, folderInfo)
 
-                val newFolderInfo = FolderInfo(folderInfo.folderId, folderInfo.label)
-
                 val oldFolderEntry = configuration.folders.find { it.folderId == folderInfo.folderId }
 
                 if (oldFolderEntry == null) {
+                    folderInfo = folderInfo.copy(isDeviceInSharedFolderWhitelist = true)
+
+                    val newFolderInfo = FolderInfo(
+                            folderId = folderInfo.folderId,
+                            label = folderInfo.label,
+                            deviceIdWhitelist = setOf(otherDeviceId),
+                            deviceIdBlacklist = emptySet()
+                    )
+
                     configuration.folders = configuration.folders + newFolderInfo
                     newSharedFolders.add(newFolderInfo)
                     logger.info("new folder shared = {}", folderInfo)
                 } else {
-                    if (oldFolderEntry != newFolderInfo) {
-                        configuration.folders = configuration.folders.filter { it != oldFolderEntry }.toSet() + setOf(newFolderInfo)
+                    if (oldFolderEntry.deviceIdWhitelist.contains(otherDeviceId)) {
+                        folderInfo = folderInfo.copy(isDeviceInSharedFolderWhitelist = true)
+
+                        if (oldFolderEntry.label != folderInfo.label) {
+                            configuration.folders = configuration.folders.filter { it != oldFolderEntry }.toSet() + setOf(
+                                    oldFolderEntry.copy(label = folderInfo.label)
+                            )
+                        }
                     }
                 }
             } else {
@@ -132,7 +147,7 @@ class ClusterConfigInfo (val folderInfo: List<ClusterConfigFolderInfo>, val newS
 
     val folderInfoById = folderInfo.associateBy { it.folderId }
     val sharedFolderIds: Set<String> by lazy {
-        folderInfo.filter { it.isShared }.map { it.folderId }.toSet()
+        folderInfo.filter { it.isShared && it.isDeviceInSharedFolderWhitelist }.map { it.folderId }.toSet()
     }
 }
 
@@ -140,7 +155,8 @@ data class ClusterConfigFolderInfo(
         val folderId: String,
         val label: String = folderId,
         val isAnnounced: Boolean = false,
-        val isShared: Boolean = false
+        val isShared: Boolean = false,
+        val isDeviceInSharedFolderWhitelist: Boolean
 ) {
     init {
         assert(folderId.isNotEmpty())

--- a/syncthing-bep/src/main/kotlin/net/syncthing/java/bep/connectionactor/ClusterConfigHandler.kt
+++ b/syncthing-bep/src/main/kotlin/net/syncthing/java/bep/connectionactor/ClusterConfigHandler.kt
@@ -122,8 +122,16 @@ object ClusterConfigHandler {
                         folderInfo = folderInfo.copy(isDeviceInSharedFolderWhitelist = true)
 
                         if (oldFolderEntry.label != folderInfo.label) {
-                            configuration.folders = configuration.folders.filter { it != oldFolderEntry }.toSet() + setOf(
+                            configuration.folders = configuration.folders.filter { it.folderId != folderInfo.folderId }.toSet() + setOf(
                                     oldFolderEntry.copy(label = folderInfo.label)
+                            )
+                        }
+                    } else {
+                        if (!oldFolderEntry.deviceIdBlacklist.contains(otherDeviceId)) {
+                            configuration.folders = configuration.folders.filter { it.folderId != folderInfo.folderId }.toSet() + setOf(
+                                    oldFolderEntry.copy(
+                                            deviceIdBlacklist = oldFolderEntry.deviceIdBlacklist + setOf(otherDeviceId)
+                                    )
                             )
                         }
                     }

--- a/syncthing-bep/src/main/kotlin/net/syncthing/java/bep/connectionactor/ClusterConfigHandler.kt
+++ b/syncthing-bep/src/main/kotlin/net/syncthing/java/bep/connectionactor/ClusterConfigHandler.kt
@@ -110,7 +110,8 @@ object ClusterConfigHandler {
                             folderId = folderInfo.folderId,
                             label = folderInfo.label,
                             deviceIdWhitelist = setOf(otherDeviceId),
-                            deviceIdBlacklist = emptySet()
+                            deviceIdBlacklist = emptySet(),
+                            ignoredDeviceIdList = emptySet()
                     )
 
                     configuration.folders = configuration.folders + newFolderInfo

--- a/syncthing-bep/src/main/kotlin/net/syncthing/java/bep/folder/FolderStatus.kt
+++ b/syncthing-bep/src/main/kotlin/net/syncthing/java/bep/folder/FolderStatus.kt
@@ -12,7 +12,12 @@ data class FolderStatus(
 ) {
     companion object {
         fun createDummy(folder: String) = FolderStatus(
-                info = FolderInfo(folder, folder),
+                info = FolderInfo(
+                        folder,
+                        folder,
+                        deviceIdBlacklist = emptySet(),
+                        deviceIdWhitelist = emptySet()
+                ),
                 stats = FolderStats.createDummy(folder),
                 indexInfo = emptyList()
         )

--- a/syncthing-bep/src/main/kotlin/net/syncthing/java/bep/folder/FolderStatus.kt
+++ b/syncthing-bep/src/main/kotlin/net/syncthing/java/bep/folder/FolderStatus.kt
@@ -16,7 +16,8 @@ data class FolderStatus(
                         folder,
                         folder,
                         deviceIdBlacklist = emptySet(),
-                        deviceIdWhitelist = emptySet()
+                        deviceIdWhitelist = emptySet(),
+                        ignoredDeviceIdList = emptySet()
                 ),
                 stats = FolderStats.createDummy(folder),
                 indexInfo = emptyList()

--- a/syncthing-bep/src/main/kotlin/net/syncthing/java/bep/index/IndexMessageQueueProcessor.kt
+++ b/syncthing-bep/src/main/kotlin/net/syncthing/java/bep/index/IndexMessageQueueProcessor.kt
@@ -106,6 +106,13 @@ class IndexMessageQueueProcessor (
     private suspend fun doHandleIndexMessageReceivedEvent(action: IndexUpdateAction) {
         val (message, clusterConfigInfo, peerDeviceId) = action
 
+        val folderInfo = clusterConfigInfo.folderInfoById[message.folder]
+                ?: throw IllegalStateException("got folder info for folder without known folder info")
+
+        if (!folderInfo.isDeviceInSharedFolderWhitelist) {
+            throw IllegalStateException("received index update for folder which is not shared")
+        }
+
         logger.info("processing index message with {} records", message.filesCount)
 
         val (indexResult, wasIndexAcquired) = indexRepository.runInTransaction { indexTransaction ->

--- a/syncthing-client-cli/src/main/kotlin/net/syncthing/java/client/cli/Main.kt
+++ b/syncthing-client-cli/src/main/kotlin/net/syncthing/java/client/cli/Main.kt
@@ -86,7 +86,7 @@ class Main(private val commandLine: CommandLine) {
                         .map { DeviceId(it.trim()) }
                         .toList()
                 System.out.println("set peers = $peers")
-                configuration.peers = peers.map { DeviceInfo(it, null) }.toSet()
+                configuration.peers = peers.map { DeviceInfo(it, it.shortId) }.toSet()
                 configuration.persistNow()
             }
             "p" -> {

--- a/syncthing-client/src/main/kotlin/net/syncthing/java/client/Connections.kt
+++ b/syncthing-client/src/main/kotlin/net/syncthing/java/client/Connections.kt
@@ -71,5 +71,11 @@ class Connections (val generate: (DeviceId) -> ConnectionActorWrapper) {
         }
     }
 
+    fun reconnect(deviceId: DeviceId) {
+        synchronized(map) {
+            map[deviceId]?.reconnect()
+        }
+    }
+
     fun subscribeToConnectionStatusMap() = connectionStatus.openSubscription()
 }

--- a/syncthing-client/src/main/kotlin/net/syncthing/java/client/SyncthingClient.kt
+++ b/syncthing-client/src/main/kotlin/net/syncthing/java/client/SyncthingClient.kt
@@ -94,6 +94,10 @@ class SyncthingClient(
         getConnections()
     }
 
+    fun reconnect(deviceId: DeviceId) {
+        connections.reconnect(deviceId)
+    }
+
     fun connectToNewlyAddedDevices() {
         getConnections()
     }

--- a/syncthing-core/src/main/kotlin/net/syncthing/java/core/beans/DeviceId.kt
+++ b/syncthing-core/src/main/kotlin/net/syncthing/java/core/beans/DeviceId.kt
@@ -5,8 +5,9 @@ import com.google.gson.stream.JsonWriter
 import net.syncthing.java.core.utils.NetworkUtils
 import org.apache.commons.codec.binary.Base32
 import java.io.IOException
+import java.io.Serializable
 
-data class DeviceId @Throws(IOException::class) constructor(val deviceId: String) {
+data class DeviceId @Throws(IOException::class) constructor(val deviceId: String): Serializable {
 
     init {
         val withoutDashes = this.deviceId.replace("-", "")

--- a/syncthing-core/src/main/kotlin/net/syncthing/java/core/beans/DeviceInfo.kt
+++ b/syncthing-core/src/main/kotlin/net/syncthing/java/core/beans/DeviceInfo.kt
@@ -17,7 +17,7 @@ package net.syncthing.java.core.beans
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonWriter
 
-data class DeviceInfo(val deviceId: DeviceId, val name: String, val isConnected: Boolean? = null) {
+data class DeviceInfo(val deviceId: DeviceId, val name: String) {
 
     companion object {
         private const val DEVICE_ID = "deviceId"
@@ -43,9 +43,6 @@ data class DeviceInfo(val deviceId: DeviceId, val name: String, val isConnected:
             )
         }
     }
-
-    constructor(deviceId: DeviceId, name: String?) :
-            this(deviceId, if (name != null && !name.isBlank()) name else deviceId.shortId, null)
 
     fun serialize(writer: JsonWriter) {
         writer.beginObject()

--- a/syncthing-core/src/main/kotlin/net/syncthing/java/core/beans/DeviceInfo.kt
+++ b/syncthing-core/src/main/kotlin/net/syncthing/java/core/beans/DeviceInfo.kt
@@ -16,8 +16,9 @@ package net.syncthing.java.core.beans
 
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonWriter
+import java.io.Serializable
 
-data class DeviceInfo(val deviceId: DeviceId, val name: String) {
+data class DeviceInfo(val deviceId: DeviceId, val name: String): Serializable {
 
     companion object {
         private const val DEVICE_ID = "deviceId"

--- a/syncthing-core/src/main/kotlin/net/syncthing/java/core/beans/FolderInfo.kt
+++ b/syncthing-core/src/main/kotlin/net/syncthing/java/core/beans/FolderInfo.kt
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2016 Davide Imbriaco
  * Copyright (C) 2018 Jonas Lochmann
  *
@@ -18,18 +18,24 @@ import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonWriter
 
 // the whitelist are device ids with which the folder should be shared
+
 // the blacklist are device ids with which the folder should not be shared
+
+// the ignored device ids are devices for which the user confirmed the blacklist entry so that
+// there should not be any question
 data class FolderInfo(
         val folderId: String,
         val label: String,
         val deviceIdWhitelist: Set<DeviceId>,
-        val deviceIdBlacklist: Set<DeviceId>
+        val deviceIdBlacklist: Set<DeviceId>,
+        val ignoredDeviceIdList: Set<DeviceId>
 ) {
     companion object {
         private const val FOLDER_ID = "folderId"
         private const val LABEL = "label"
         private const val DEVICE_ID_WHITELIST = "deviceWhitelist"
         private const val DEVICE_ID_BLACKLIST = "deviceBlacklist"
+        private const val IGNORED_DEVICE_ID_LIST = "ignoredDeviceIdList"
 
         fun parse(reader: JsonReader): FolderInfo {
             var folderId: String? = null
@@ -37,6 +43,7 @@ data class FolderInfo(
             // the following fields were added later and thus have got a default value
             var deviceIdWhitelist = emptySet<DeviceId>()
             var deviceIdBlacklist = emptySet<DeviceId>()
+            var ignoredDeviceIdList = emptySet<DeviceId>()
 
             reader.beginObject()
             while (reader.hasNext()) {
@@ -65,6 +72,17 @@ data class FolderInfo(
 
                         reader.endArray()
                     }
+                    IGNORED_DEVICE_ID_LIST -> {
+                        reader.beginArray()
+
+                        ignoredDeviceIdList = mutableSetOf<DeviceId>().apply {
+                            while (reader.hasNext()) {
+                                add(DeviceId(reader.nextString()))
+                            }
+                        }
+
+                        reader.endArray()
+                    }
                     else -> reader.skipValue()
                 }
             }
@@ -74,7 +92,8 @@ data class FolderInfo(
                     folderId = folderId!!,
                     label = label!!,
                     deviceIdBlacklist = deviceIdBlacklist,
-                    deviceIdWhitelist = deviceIdWhitelist
+                    deviceIdWhitelist = deviceIdWhitelist,
+                    ignoredDeviceIdList = ignoredDeviceIdList
             )
         }
     }
@@ -82,6 +101,12 @@ data class FolderInfo(
     init {
         assert(!folderId.isEmpty())
         assert(deviceIdWhitelist.find { deviceIdBlacklist.contains(it) } == null)
+    }
+
+    val notIgnoredBlacklistEntries: Set<DeviceId> by lazy {
+        deviceIdBlacklist
+                .filterNot { ignoredDeviceIdList.contains(it) }
+                .toSet()
     }
 
     override fun toString(): String {
@@ -102,7 +127,10 @@ data class FolderInfo(
         deviceIdBlacklist.forEach { writer.value(it.deviceId) }
         writer.endArray()
 
+        writer.name(IGNORED_DEVICE_ID_LIST).beginArray()
+        ignoredDeviceIdList.forEach { writer.value(it.deviceId) }
+        writer.endArray()
+
         writer.endObject()
     }
-
 }


### PR DESCRIPTION
This closes <https://github.com/syncthing/syncthing-lite/issues/17>. After the update, any folder and device combination must be confirmed. For every new folder, the first device which shares it is accepted automatically.